### PR TITLE
enables elastic client timeout configuration via --timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Streams documents out of the specified Elastic index endpoint as JSON.
 
 Options:
 
-* `search`: Client search options as JSON, e.g. `{"body": {"query": {"bool": {"filter": {"term": {"foo": "bar"}}}}}}`. Passed directly to `client.search`; see [ElasticSearch's Javascript API docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-search). `scroll` defaults to `10s` and `size` to `100`.
+* `--search`: Client search options as JSON, e.g. `{"body": {"query": {"bool": {"filter": {"term": {"foo": "bar"}}}}}}`. Passed directly to `client.search`; see [ElasticSearch's Javascript API docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-search). `scroll` defaults to `10s` and `size` to `100`.
+* `--timeout`: Set the timeout for the Elastic client (in ms).
 
 ### put
 
@@ -48,7 +49,8 @@ Put documents (as JSON strings) from stdin into the specified Elastic index endp
 
 Options:
 
-* `batch`: size of bulk batches. Default: `100`.
+* `--batch`: size of bulk batches. Default: `100`.
+* `--timeout`: Set the timeout for the Elastic client (in ms).
 
 ## Tips
 

--- a/cmd/get-args.js
+++ b/cmd/get-args.js
@@ -5,9 +5,11 @@ const yargs = require('yargs');
 module.exports = () => yargs
   .command('get', 'gets docs from index', yargs => yargs
     .coerce('search', JSON.parse)
+    .number('timeout')
   )
   .command('put', 'put docs into index', yargs =>
     yargs
       .number('batch')
+      .number('timeout')
   )
   .argv;

--- a/cmd/init-cmd.js
+++ b/cmd/init-cmd.js
@@ -10,7 +10,8 @@ const getArgs = require('./get-args'),
 function cmdGetDocs(args) {
   return getDocs(args._[1], {
     parse: false,
-    search: args.search
+    search: args.search,
+    requestTimeout: args.timeout
   });
 }
 
@@ -18,7 +19,7 @@ function cmdPutDocs(args) {
 
   return util.readStdin()
     .map(JSON.parse)
-    .through(_.partialRight(putDocs, args._[1], { batch: args.batch }))
+    .through(_.partialRight(putDocs, args._[1], { batch: args.batch, requestTimeout: args.timeout }))
     .map(JSON.stringify);
 }
 

--- a/lib/get-docs.js
+++ b/lib/get-docs.js
@@ -10,9 +10,9 @@ const util = require('../lib/util');
  * @param  {Object}  [options.search] Specify query to filter docs
  * @return {Stream} of objects or JSON strings
  */
-function getDocs(elastic, {parse = true, search} = {}) {
+function getDocs(elastic, {parse = true, search, requestTimeout} = {}) {
   const {host, index} = util.parseElastic(elastic),
-    client = util.getEsClient({host}),
+    client = util.getEsClient({host, requestTimeout}),
     opts = Object.assign({index}, search);
 
   return util.scrollStream(client, opts)

--- a/lib/put-docs.js
+++ b/lib/put-docs.js
@@ -36,9 +36,9 @@ function docsToBulkActions(docs, index) {
  * @param  {number} [options.batch] Number of items to include in each bulk req
  * @return {Stream} of bulk results
  */
-function putDocs(stream, elastic, {batch = DEFAULT_BATCH_SIZE} = {}) {
+function putDocs(stream, elastic, {batch = DEFAULT_BATCH_SIZE, requestTimeout} = {}) {
   const {host, index} = util.parseElastic(elastic),
-    client = util.getEsClient({host});
+    client = util.getEsClient({host, requestTimeout});
 
   return stream
     .batch(batch)


### PR DESCRIPTION
This PR introduces a new `--timeout` flag to the `get` and `put` commands. The flag accepts an integer (in milliseconds) and will set `requestTimeout` when initializing the client.

When not set the client will use the default timeout (at the time of this PR that was `30000ms` or `30s`).

#### Examples

##### Get records with a timeout of 60s
```sh
ess get --timeout 60000 http://localhost:9200
```
##### Put records with a timeout of 10s
```sh
ess get http://localhost:9200 | ess put --timeout 10000 http://example.com:9200
```